### PR TITLE
Improve mobile usability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,20 +13,50 @@ body {
 }
 
 input {
-  padding: 10px;
+  padding: 0.75% 1%;
   border-radius: 4px;
   border: 10px;
-  width: 200px
+  width: 51%;
 }
 
 .Results {
   background-color: white;
-  margin-left: 150px;
-  margin-right: 150px;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 20px;
   border-radius: 8px;
   color: black;
-  padding: 10px;
+  padding: 5% 20%;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  width: fit-content;
 }
 
+
+/* For Mobile */
+@media screen and (max-width: 540px) {
+  body {
+    background-color: red;
+  }
+  input {
+    width: 75%;
+
+  }
+  
+  .Results {
+  }
+}
+
+/* For Tablets */
+@media screen and (min-width: 540px) and (max-width: 780px) {
+  body {
+    background-color: pink;
+  }
+
+  input {
+    width: 65%;
+  }
+  
+  .Results {
+    padding: 5% 25%;
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -34,24 +34,13 @@ input {
 
 /* For Mobile */
 @media screen and (max-width: 540px) {
-  body {
-    background-color: red;
-  }
   input {
     width: 75%;
-
-  }
-  
-  .Results {
   }
 }
 
 /* For Tablets */
 @media screen and (min-width: 540px) and (max-width: 780px) {
-  body {
-    background-color: pink;
-  }
-
   input {
     width: 65%;
   }


### PR DESCRIPTION
Closes: #1
- Widened input
- Adjusted input and results size to be similar size for different screen sizes. 
- Mobile: Input and results takes up most of width
- Tablet: Input and results takes up larger width
- Desktop: Input and result takes up medium size

Mobile
<img width="643" alt="Screen Shot 2022-03-18 at 9 44 01 PM" src="https://user-images.githubusercontent.com/45278655/159014113-5322c930-67df-42c2-b8ec-bf1612475061.png">

Tablet
<img width="869" alt="Screen Shot 2022-03-18 at 9 43 45 PM" src="https://user-images.githubusercontent.com/45278655/159014139-6df5d5ff-b197-42ec-b492-63d56504cbf6.png">

Desktop
![Screen Shot 2022-03-18 at 9 43 04 PM](https://user-images.githubusercontent.com/45278655/159014136-c5bdaaec-86bb-4e8b-b244-1c7f2888f242.png)
 